### PR TITLE
fixing subheaders and tabs in markdown for ISLE docker cheatsheet

### DIFF
--- a/docs/07_appendices/isle-cheatsheet-docker-commands.md
+++ b/docs/07_appendices/isle-cheatsheet-docker-commands.md
@@ -5,41 +5,41 @@ Docker commands that are useful to installing or updating ISLE.
 
 ## Docker Containers
 
-* List Containers
-   * Show currently running containers
-      * `docker ps`
-   * Show both currently running and all past containers
-      * `docker ps -a`
-   * Show names of all existing volumes
-     * `docker volume ls`
+### List Containers
+  * Show currently running containers
+    * `docker ps`
+  * Show both currently running and all past containers
+    * `docker ps -a`
+  * Show names of all existing volumes
+    * `docker volume ls`
 
-* Stop Containers
-    * Stop all current containers
-      * `docker-compose stop`
-    * Stop one or more named containers
-      * usage: `docker stop [CONTAINER_NAME(S)]`
-      * example: `docker stop isle-tomcat isle-solr`
-    * Stop ALL containers (including old ones)
-      * `docker stop $(docker ps -a -q)`
+### Stop Containers
+  * Stop all current containers
+    * `docker-compose stop`
+  * Stop one or more named containers
+    * usage: `docker stop [CONTAINER_NAME(S)]`
+    * example: `docker stop isle-tomcat isle-solr`
+  * Stop ALL containers (including old ones)
+    * `docker stop $(docker ps -a -q)`
 
-* Start Containers
+### Start Containers
   * Start all current containers
     * `docker-compose start`
   * Start ALL containers (including old ones)
     * `docker start $(docker ps -a -q)`
 
-* Pull Containers
+### Pull Containers
   * Pull down all images from Docker Hub
     * `docker-compose pull`
   * Pull one specific image from Docker Hub
     * usage: `docker pull [GROUP]/[REPO]`
     * example: `docker pull islandoracollabgroup/isle-fedora:latest`
 
-* Up Containers
+### Up Containers
   * Launch all containers (creates volumes and starts containers)
     * `docker-compose up -d`
 
-* Remove Containers
+### Remove Containers
   * Remove All: Stop and remove all containers and all volumes
     * `docker-compose down -v`
   * WARNING! This will remove all stopped containers, all networks not used by a container, all images that lack an associated container, and all build cache.
@@ -53,61 +53,62 @@ Docker commands that are useful to installing or updating ISLE.
   * WARNING! This will remove ALL containers on the machine!
     * `docker rm $(docker ps -a -q)`
 
-* Watching Docker Logs
+### Watching Docker Logs
   * Show the last 10 lines (`--tail 10`) of a container's logs; `-f` means continuous/live feed
     * usage: `docker logs -f --tail 10 [CONTAINER_NAME]`
     * example: `docker logs -f --tail 10 isle-apache-ld`
 
-* Locate Docker Volume
+### Locate Docker Volume
   * usage: `docker volume inspect [VOLUME_NAME]`
   * example: `docker volume inspect isle_fed-data`
   * resultant display is a JSON array that contains a location like this:
     * "Mountpoint": "/var/lib/docker/volumes/isle_fed-data/_data"
 
-* Port Lookups
+### Port Lookups
   * Query what is using a specific port number
     * `docker ps | grep 8381`
   * Query what is using a specific port number
     * `lsof -i :8381`
 
-* Shell into Docker Container
+### Shell into Docker Container
   * usage: `docker exec -it [CONTAINER_NAME] bash`
   * example: `docker exec -it isle-apache-ld bash`
 
-* Shell into Docker Container and Open a File
+### Shell into Docker Container and Open a File
   * usage: `docker exec -it [CONTAINER_NAME] [FILE_NAME]`
   * example: `docker exec -it isle-apache-ld bash /utility-scripts/isle_drupal_build_tools/isle_islandora_installer.sh`
 
 
 ## Docker Service
 
-* Show Docker Status
+### Show Docker Status
   * `sudo service docker status`
-* Restart Docker Service
+### Restart Docker Service
   * `sudo /bin/systemctl restart docker.service`
-* Restart Docker Service (Alternate)
+### Restart Docker Service (Alternate)
   * `sudo service docker restart`
 
 
 ## UNIX Commands
 
-* Quickly View a File, Using Cat
+### Quickly View a File, Using Cat
   * usage: `cat [FILE_NAME]`
   * example: `cat /etc/hosts`
 
-* Ping to Test Connectivity
+### Ping to Test Connectivity
   * usage: `ping [DOMAIN]`
   * example: `ping www.google.com`
   * example: `ping isle.localdomain`
 
-* DNS Lookup and Querying Tool
+### DNS Lookup and Querying Tool
   * usage: `dig [DOMAIN]`
   * example: `dig www.google.com`
   * example: `dig isle.localdomain`
 
-* EXTREME CAUTION: Remove Directory: Recursively and with Force
+### EXTREME CAUTION: Remove Directory: Recursively and with Force
   * usage: `sudo rm -rf [DIRECTORY_NAME]`
   * example: `sudo rm -rf /var/tmp/scrap/`
+
 
 # *CAREFUL! BELOW THERE BE DRAGONS*
 
@@ -115,7 +116,7 @@ Docker commands that are useful to installing or updating ISLE.
 ## How to Remove ALL Docker Containers and then Pull Down Fresh Images
 
 1. Stop all Current Containers
-    * `docker-compose stop` 
+    * `docker-compose stop`
 1. WARNING! This will remove: all stopped containers; etc.
     * `docker system prune --all`
 1. Delete "data" folder in ISLE-Developer folder so logs are fresh and clean
@@ -128,13 +129,11 @@ Docker commands that are useful to installing or updating ISLE.
 
 ## How Testers Can Maintain a Nice Clean Environment
 
-Show Currently Running and All Past Containers
+### Show Currently Running and All Past Containers
   * `docker ps -a`
 
-* Let's say you discover you have two older containers named `isle-web`, `isle-db`) and you want to remove them:
-
+### Let's say you discover you have two older containers named `isle-web`, `isle-db`) and you want to remove them:
   * Example to stop these 2 containers
     * `docker stop isle-web isle-db`
-
   * Example to remove these 2 containers
     * `docker rm isle-web isle-db`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,7 +58,7 @@ nav:
   - 'Note/Warning about installing on Redhat': '07_appendices/redhat.md'
   - 'Installing on Google Cloud Platform (Google Doc)': 'https://docs.google.com/document/d/1r-I9n8mUhlJ5Z-X9AO-RrikhzH6I8bTPIL25LmtRbxE'
   - 'ISLE Cheat Sheet: Docker commands': '07_appendices/isle-cheatsheet-docker-commands.md'
-- 'About': 
+- 'About':
   - 'About ISLE': '08_about/about.md'
   - 'Contributing to ISLE': '08_about/contributing_to_ISLE.md'
   - 'About Maintainers': '08_about/about_maintainers.md'


### PR DESCRIPTION
fixing the markdown to make it easily readable (MkDocs reinterprets standard markdown... argh.). Fixed.