### PR TITLE
docker cheatsheet added links, clearer explanations and layout

### DIFF
--- a/docs/10_cookbook_recipes/isle-cheatsheet-docker-commands.md
+++ b/docs/10_cookbook_recipes/isle-cheatsheet-docker-commands.md
@@ -7,88 +7,74 @@ Docker commands that are useful to installing or updating ISLE.
 
 ## Docker Containers
 
-### List Containers
-  * Show currently running containers
-    * `docker ps`
-  * Show both currently running and all past containers
-    * `docker ps -a`
-  * Show names of all existing volumes
-    * `docker volume ls`
+### [List Containers](https://docs.docker.com/engine/reference/commandline/ps/)
+  * `docker ps`     # Show all running containers
+  * `docker ps -a`  # Show all running and stopped containers
 
-### Stop Containers
-  * Stop all current containers
-    * `docker-compose stop`
-  * Stop one or more named containers
-    * usage: `docker stop [CONTAINER_NAME(S)]`
+### [List Volumes](https://docs.docker.com/engine/reference/commandline/volume_ls/)
+* `docker volume ls`  # List all volumes
+
+### [Start Containers](https://docs.docker.com/compose/reference/start/)
+  * `docker-compose start` # Starts existing containers for a service
+  * `docker start $(docker ps -a -q)` # Start all running and stopped containers
+
+### [Stop Containers](https://docs.docker.com/compose/reference/stop/)
+  * `docker-compose stop` # Stops running containers without removing them
+  * `docker stop [CONTAINER_NAME(S)]` # Stop one or more named containers
     * example: `docker stop isle-tomcat isle-solr`
-  * Stop ALL containers (including old ones)
-    * `docker stop $(docker ps -a -q)`
+  * `docker stop $(docker ps -a -q)` # Stop all running and stopped containers
 
-### Start Containers
-  * Start all current containers
-    * `docker-compose start`
-  * Start ALL containers (including old ones)
-    * `docker start $(docker ps -a -q)`
-
-### Pull Containers
-  * Pull down all images from Docker Hub
-    * `docker-compose pull`
-  * Pull one specific image from Docker Hub
-    * usage: `docker pull [GROUP]/[REPO]`
+### [Pull Containers]([https://docs.docker.com/compose/reference/pull/)
+  * `docker-compose pull` # Pull down all images from Docker Hub
+  * `docker pull [GROUP]/[REPO]` # Pull one specific image from Docker Hub
     * example: `docker pull islandoracollabgroup/isle-fedora:latest`
 
-### Up Containers
-  * Launch all containers (creates volumes and starts containers)
-    * `docker-compose up -d`
+### [Up Containers]([https://docs.docker.com/compose/reference/up/)
+  * `docker-compose up -d` # Launch all containers for this service
 
-### Remove Containers
-  * Delete an (unused) volume
-    * usage: `docker volume rm [VOLUME_NAME]`
+### [Shell Into Docker Container](https://docs.docker.com/v17.12/engine/reference/commandline/exec/)
+  * `docker exec -it [CONTAINER_NAME] bash` # Shell Into Docker Container
+    * example: `docker exec -it isle-apache-ld bash`
+  * `docker exec -it [CONTAINER_NAME] [FILE_NAME]` # Shell Into Docker Container and Open a File
+    * example: `docker exec -it isle-apache-ld bash /utility-scripts/isle_drupal_build_tools/isle_islandora_installer.sh`
+
+### [Docker Service](https://docs.docker.com/engine/reference/commandline/docker/)
+  * `sudo service docker status` # Show Docker Status
+  * `sudo /bin/systemctl restart docker.service` # Restart Docker Service
+  * `sudo service docker restart` # Restart Docker Service (alternate)
+
+### [Remove Volumes](https://docs.docker.com/engine/reference/commandline/volume_rm/)
+  * `docker volume rm [VOLUME_NAME]` # Remove one or more volumes. You cannot remove a volume that is in use by a container.
     * example: `docker volume rm isle_fed-data`
-  * Remove one or more (stopped) containers
-    * usage: `docker rm [CONTAINER_NAME(S)]`
-    * example: `docker rm isle_fed-data`
-  * **WARNING!** Never run this command in production. Never ever. ONLY consider doing this on your Demo Local machine. This command will delete all Docker containers AND all attached Docker Volumes (TBD: does this remove only-running or running-and-stopped containers). This command will not delete your git repository or the paths or contents of your bind mounts.
-    * `docker-compose down -v`
-  * **WARNING!**! This will remove all stopped containers, all networks not used by a container, all images that lack an associated container, and all build cache.
-    * `docker system prune --all`
-  * **WARNING!**! This will remove ALL containers on the machine!
-    * `docker rm $(docker ps -a -q)`
 
-### Watching Docker Logs
-  * Show the last 10 lines (`--tail 10`) of a container's logs; `-f` means continuous/live feed
-    * usage: `docker logs -f --tail 10 [CONTAINER_NAME]`
+### [Remove Containers](https://docs.docker.com/engine/reference/commandline/rm/)
+  * `docker rm [CONTAINER_NAME(S)]` # Remove one or more containers
+    * example: `docker rm isle_fed-data`
+
+### [Watching Docker Logs](https://docs.docker.com/engine/reference/commandline/logs/)
+  * `docker logs -f --tail 10 [CONTAINER_NAME]` # Show the last 10 lines (`--tail 10`) of a container's logs; `-f` means continuous/live feed
     * example: `docker logs -f --tail 10 isle-apache-ld`
 
-### Locate Docker Volume
-  * usage: `docker volume inspect [VOLUME_NAME]`
-  * example: `docker volume inspect isle_fed-data`
-  * resultant display is a JSON array that contains a location like this:
-    * `"Mountpoint": "/var/lib/docker/volumes/isle_fed-data/_data"`
+### [Locate Docker Volume](https://docs.docker.com/engine/reference/commandline/volume_inspect/)
+  * `docker volume inspect [VOLUME_NAME]` # Locate Docker Volume
+    * example: `docker volume inspect isle_fed-data`
+    * resultant display is a JSON array that contains a location like this:
+        * `"Mountpoint": "/var/lib/docker/volumes/isle_fed-data/_data"`
 
-### Port Lookups
-  * Query what is using a specific port number
-    * `docker ps | grep 8381`
-  * Query what is using a specific port number
-    * `lsof -i :8381`
-
-### Shell Into Docker Container
-  * usage: `docker exec -it [CONTAINER_NAME] bash`
-  * example: `docker exec -it isle-apache-ld bash`
-
-### Shell Into Docker Container and Open a File
-  * usage: `docker exec -it [CONTAINER_NAME] [FILE_NAME]`
-  * example: `docker exec -it isle-apache-ld bash /utility-scripts/isle_drupal_build_tools/isle_islandora_installer.sh`
+### [Port Lookups](https://docs.docker.com/engine/reference/commandline/port/)
+  * `docker port [CONTAINER_NAME]` # List port mappings or a specific mapping for the container
+  * `docker ps | grep 8381` # Query what is using a specific port number
+  * `lsof -i :8381` # Query what is using a specific port number
 
 
-## Docker Service
+## Docker: WARNING: BE CAREFUL WITH THESE COMMANDS
 
-### Show Docker Status
-  * `sudo service docker status`
-### Restart Docker Service
-  * `sudo /bin/systemctl restart docker.service`
-### Restart Docker Service (alternate)
-  * `sudo service docker restart`
+### [Delete All Containers, Networks, Volumes and Images](https://docs.docker.com/compose/reference/down/)
+  * `docker-compose down -v` # **WARNING!** NEVER run this command in production. ONLY consider doing this on your Demo Local machine. This command will delete all Docker containers, networks, volumes, and images created by `up`. (This command will not delete your git repository or the paths or contents of your bind mounts.)
+### [Remove Unused Data](https://docs.docker.com/engine/reference/commandline/system_prune/)
+  * `docker system prune --all` # **WARNING!** Remove all unused containers, networks, images and volumes. (Translation: This will remove all stopped containers, all networks not used by a container, all images that lack an associated container, and all build cache.)
+### [Remove All Containers](https://docs.docker.com/engine/reference/commandline/rm/)
+  * `docker rm $(docker ps -a -q)` # **WARNING!** This will remove ALL containers on the machine!
 
 
 ## UNIX Commands


### PR DESCRIPTION
- used `git rebase` to put my local branch at head of current commits, then pushed to my fork.