### PR TITLE
Added previous release notes to nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,4 +62,7 @@ nav:
     - 'Release Process': 'contributor-docs/release-process.md'
     - 'Testing Guide': 'contributor-docs/testing-guide.md'
   - 'Get Help': 'about/get-help.md'
-- 'Release Notes': 'release-notes/release.md'
+- 'Release Notes':
+  - 'Latest release: 1.1.1': 'release-notes/release.md'
+  - 'Previous releases': 
+     - '1.1': 'release-notes/release-1-1.md'


### PR DESCRIPTION
I don't remember if I ever pushed this change out.  I think it's important that we keep the history of release notes.  If the link in nav was deleted intentionally, let me know... I think it's worth a discussion.