### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,3 @@ ISLE is a collaborative project that addresses two of the most significant pain-
 ## ISLE Repositories
 * ISLE: https://github.com/Islandora-Collaboration-Group/ISLE
 * ISLE Documentation: https://github.com/Islandora-Collaboration-Group/ISLE-Documentation
-* ISLE Development (bleeding edge version): https://github.com/Islandora-Collaboration-Group/ISLE-Development


### PR DESCRIPTION
Remove link to bleeding edge version. Appears obsolete.